### PR TITLE
Program header load

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,6 @@ fn main() {
     // add them to the TAB file.
     for elf_file in opt.input {
         let mut fsfile = fs::File::open(&elf_file.path).expect("Could not open the .elf file.");
-        let elffile = elf::File::open_stream(&mut fsfile).expect("Could not open the .elf file.");
 
         // The TBF will be written to the same place as the ELF, with a .tbf
         // extension.
@@ -119,13 +118,6 @@ fn main() {
             .open(tbf_path.clone())
             .unwrap();
 
-        // Adding padding to the end of cortex-m apps. Check for a cortex-m app
-        // by inspecting the "machine" value in the elf header. 0x28 is ARM (see
-        // https://en.wikipedia.org/wiki/Executable_and_Linkable_Format#File_header
-        // for a list).
-        //
-        // RISC-V apps do not need to be sized to power of two.
-        let add_trailing_padding = elffile.ehdr.machine.0 == 0x28;
 
         // Do the conversion to a tock binary.
         if opt.verbose {
@@ -136,7 +128,6 @@ fn main() {
         // it to a file.
         let mut output_vector = Vec::<u8>::new();
         convert::elf_to_tbf(
-            &elffile,
             &mut fsfile,
             &mut output_vector,
             opt.package_name.clone(),
@@ -148,7 +139,6 @@ fn main() {
             opt.permissions.to_vec(),
             (opt.write_id, opt.read_ids.clone(), opt.access_ids.clone()),
             minimum_tock_kernel_version,
-            add_trailing_padding,
             opt.disabled,
             opt.minimum_footer_size,
             opt.app_version,


### PR DESCRIPTION
Merged all changes and bugfixes. Tested with all libtock-c examples buit for RiscV and ARM.
Breakdown: 1716 ELFs converted to TBF. One using the elf2tab compilation from tock/elf2tab master. The other using bincsh/elf2tab.

All TBF files generated have the same sizes. 1704 TBF files are binary identical.12 files were different:
examples/cxx_hello/cortex-m3/cortex-m3.tbf
examples/cxx_hello/cortex-m7/cortex-m7.tbf
examples/cxx_hello/cortex-m0/cortex-m0.tbf
examples/cxx_hello/cortex-m4/cortex-m4.tbf
examples/ble_passive_scanning/cortex-m3/cortex-m3.tbf
examples/ble_passive_scanning/cortex-m7/cortex-m7.tbf
examples/ble_passive_scanning/cortex-m0/cortex-m0.tbf
examples/ble_passive_scanning/cortex-m4/cortex-m4.tbf
examples/lvgl/cortex-m3/cortex-m3.tbf
examples/lvgl/cortex-m7/cortex-m7.tbf
examples/lvgl/cortex-m0/cortex-m0.tbf
examples/lvgl/cortex-m4/cortex-m4.tbf

These files have ARM's unwinding section (ARM.exidx), which is now inserted into TBF. tock/elf2tab was not inserting this content - none of them are using unwinding, but if they did, they would not work with elf2tab.